### PR TITLE
Increased the sso login timelimit to 10 minutes from 30 sec

### DIFF
--- a/internal/common/services.go
+++ b/internal/common/services.go
@@ -221,7 +221,7 @@ func (s *Services) IsAWSConfigured() bool {
 		return false
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	creds, err := s.Provider.AwsConfig.Credentials.Retrieve(ctx)

--- a/internal/sso/client.go
+++ b/internal/sso/client.go
@@ -177,7 +177,7 @@ func (c *RealSSOClient) SSOLogin(awsProfile string, refresh, noBrowser bool) err
 	}
 	args = append(args, "--profile", awsProfile)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	err := c.Executor.RunInteractiveCommand(ctx, "aws", args...)

--- a/internal/sso/session.go
+++ b/internal/sso/session.go
@@ -235,7 +235,7 @@ func (c *RealSSOClient) runSSOLogin(sessionName string) error {
 
 	fmt.Println("\nInitiating AWS SSO login... (this may open a browser window)")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	if err := c.Executor.RunInteractiveCommand(ctx, "aws", "sso", "login", "--sso-session", sessionName); err != nil {

--- a/utils/common/common.go
+++ b/utils/common/common.go
@@ -71,7 +71,7 @@ func terminateProcess(pid int) error {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	for {
 		select {


### PR DESCRIPTION
## Description

- Increased the sso login timelimit to 10 mins from 30 secs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased timeout durations for AWS configuration checks and process termination, reducing the likelihood of premature timeouts.
  * Extended the allowed time for AWS SSO login processes, providing users with more time to complete interactive authentication steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->