### PR TITLE
Added option to create session on sso setup when only one session is available on the custom config path

### DIFF
--- a/internal/sso/session.go
+++ b/internal/sso/session.go
@@ -36,17 +36,6 @@ func (c *RealSSOClient) LoadOrCreateSession(name, startURL, region string) (stri
 	if configPath != "" && len(c.Config.RawCustomConfig.SSOSessions) > 0 {
 		fmt.Printf("Loaded existing configuration from '%s'\n", configPath)
 
-		if len(c.Config.RawCustomConfig.SSOSessions) == 1 && name == "" && startURL == "" && region == "" {
-			ssoSession := &c.Config.RawCustomConfig.SSOSessions[0]
-			ssoSession.StartURL = strings.TrimSuffix(ssoSession.StartURL, "#")
-			if ssoSession.Scopes == "" {
-				ssoSession.Scopes = "sso:account:access"
-			}
-			fmt.Printf("Using SSO session: %s (Start URL: %s, Region: %s)\n",
-				ssoSession.Name, ssoSession.StartURL, ssoSession.Region)
-			return configPath, ssoSession, nil
-		}
-
 		ssoSession, err := c.SelectSSOSession()
 		if err != nil {
 			if errors.Is(err, promptUtils.ErrInterrupted) {


### PR DESCRIPTION
## Description

- Added option to create session on sso setup when only one session is available on the custom config path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You’ll now be prompted to select an SSO session even if only one exists, providing explicit control over which session is used.
  * The selection flow also offers the option to create a new SSO session when needed.
  * Improved clarity during setup by consistently guiding users through session selection rather than auto-using an existing session, reducing accidental usage of unintended configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->